### PR TITLE
count() method returns string

### DIFF
--- a/joli.js
+++ b/joli.js
@@ -218,7 +218,7 @@ joli.model.prototype = {
       });
     }
 
-    return q.execute();
+    return parseInt(q.execute(), 10);
   },
 
   // no callbacks, more efficient


### PR DESCRIPTION
It looks like some_model.count() returns string instead of integer.

Tested on Titanium Developer 1.2.2 with Android SDK
