### PR TITLE
Appcelerator 1.8 / V8 changes: getType needs a different Array check

### DIFF
--- a/joli.js
+++ b/joli.js
@@ -38,7 +38,7 @@ var joli = {
     getType: function(obj) {
         if (typeof obj === "undefined" || obj === null || (typeof obj === "number" && isNaN(obj))) {
             return false;
-        } else if (obj.constructor === Array) {
+        } else if (obj.constructor === Array || (Array.isArray && Array.isArray(obj))) {
             return "array";
         } else {
             return typeof obj;


### PR DESCRIPTION
With Appcelerator 1.8 and V8 on Android, obj.constructor is [Function].  V8 has Array.isArray, so we can use that for V8.
