### PR TITLE
fieldCount() no longer exists on iOS

### DIFF
--- a/joli.js
+++ b/joli.js
@@ -605,13 +605,7 @@ var joliCreator = function() {
                 return result;
             }
 
-            var fieldCount;
-
-            if (Titanium.Platform.name !== 'android') {
-                fieldCount = rows.fieldCount();
-            } else {
-                fieldCount = rows.fieldCount;
-            }
+            var fieldCount = rows.fieldCount;
 
             switch (hydratationMode) {
                 case 'array':


### PR DESCRIPTION
fieldCount as a property now has API parity across both.  http://docs.appcelerator.com/titanium/latest/#!/api/Titanium.Database.ResultSet-method-fieldCount
