### PR TITLE
in Titanium SDK >=3.3.0, fieldCount is a read-only property

### DIFF
--- a/joli.js
+++ b/joli.js
@@ -605,13 +605,7 @@ var joliCreator = function() {
                 return result;
             }
 
-            var fieldCount;
-
-            if (Titanium.Platform.name !== 'android') {
-                fieldCount = rows.fieldCount();
-            } else {
-                fieldCount = rows.fieldCount;
-            }
+            var fieldCount = (typeof(rows.fieldCount) == "function") ? rows.fieldCount() : rows.fieldCount;
 
             switch (hydratationMode) {
                 case 'array':


### PR DESCRIPTION
I think this fix is superior to #43 because it should work on all versions.
