### PR TITLE
fromArray(): Always ensure _originalData is available

### DIFF
--- a/joli.js
+++ b/joli.js
@@ -794,8 +794,8 @@ var joliCreator = function() {
         fromArray: function(data) {
             var wasNew = this.isNew ? this.isNew() : true;
 
+            this._originalData = this._originalData || {};
             if (typeof data.id !== 'undefined') {
-                this._originalData = this._originalData || {};
                 this.isNew = function() {
                     return false;
                 };


### PR DESCRIPTION
Otherwise this statement:

```
if ((this._originalData && !this._originalData[colName]) || this.isNew()) {
    this._originalData[colName] = data[colName];
}
```

Might try to set a value on `this._originalData` when it doesn't exist if `this.isNew()`
